### PR TITLE
공휴일 API 호출 긴급 수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -87,8 +87,34 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ env.AWS_REGION }}
+#        run: |
+#          sudo docker rm -f $(docker ps -qa)
+#          sudo docker pull ${{ secrets.DOCKER_USERNAME }}/{{ secrets.DOCKER_REPO }}:${{ steps.get-version.outputs.VERSION }}
+#          sudo docker run -d -p 80:8080 ${{ secrets.DOCKER_USERNAME }}/{{ secrets.DOCKER_REPO }}:${{ steps.get-version.outputs.VERSION }}
+#          sudo docker image prune -f
+
+
+    # Add github ip to AWS (7)
+    - name: Add GitHub IP to AWS
+      run: |
+        aws ec2 authorize-security-group-ingress --group-id ${{ secrets.AWS_SG_ID }} --protocol tcp --port ${{ secrets.EC2_SSH_PORT }} --cidr ${{ steps.ip.outputs.ipv4 }}/32
+
+    # AWS EC2 Server Connect & Docker 명령어 실행 (8)
+    - name: AWS EC2 Connection
+      uses: appleboy/ssh-action@v0.1.6
+      with:
+        host: ${{ secrets.AWS_EC2_HOST }}
+        username: ec2-user
+        password: ${{ secrets.AWS_EC2_PASSWORD }}
+        port: ${{ secrets.EC2_SSH_PORT }}
+        timeout: 60s
         script: |
           sudo docker rm -f $(docker ps -qa)
           sudo docker pull ${{ secrets.DOCKER_USERNAME }}/{{ secrets.DOCKER_REPO }}:${{ steps.get-version.outputs.VERSION }}
           sudo docker run -d -p 80:8080 ${{ secrets.DOCKER_USERNAME }}/{{ secrets.DOCKER_REPO }}:${{ steps.get-version.outputs.VERSION }}
           sudo docker image prune -f
+
+    # REMOVE Github IP FROM security group (9)
+    - name: Remove IP FROM security group
+      run: |
+        aws ec2 revoke-security-group-ingress --group-id ${{ secrets.AWS_SG_ID }} --protocol tcp --port ${{ secrets.EC2_SSH_PORT }} --cidr ${{ steps.ip.outputs.ipv4 }}/32

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM openjdk:11
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENV TZ Asia/Seoul
-ENV APP_VERSION=v1.0.8
+ENV APP_VERSION=v1.0.9
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/docs/UPDATE-REPORT.md
+++ b/docs/UPDATE-REPORT.md
@@ -1,6 +1,7 @@
 # 버전 정보
 |   버전    |     날짜     |
 |:-------:|:----------:|
+| v1.0.9  | 2023/12/25 |
 | v1.0.8  | 2023/11/09 |
 | v1.0.73 | 2023/11/06 |
 | v1.0.72 | 2023/10/25 |
@@ -26,15 +27,94 @@
 |:--:|:---:|
 | ✅  |  🟩 |
 
+## 시스템 개선(v1.0.8)
+### 이력
+* ✅ **[23/12/25]** 공휴일 API 호출 시 필드 타입 문제
+  * 같은 item 필드에서 데이터에 따라 Object 또는 Array를 내려줌
+  * `JsonDeserializer`를 상속받은 `HolidayItemDeserializer`를 구현하여 해결
+```
+## 응답 결과가 item의 value가 Object인 경우
+{
+  "response": {
+    "header": {
+      "resultCode": "00",
+      "resultMsg": "NORMAL SERVICE."
+    },
+    "body": {
+      "items": {
+        "item": {
+          "dateKind": "01",
+          "dateName": "기독탄신일",
+          "isHoliday": "Y",
+          "locdate": 20231225,
+          "seq": 1
+        }
+      },
+      "numOfRows": 10,
+      "pageNo": 1,
+      "totalCount": 1
+    }
+  }
+}
+  
+## 응답 결과가 item의 value가 Array인 경우
+{
+  "response": {
+    "header": {
+      "resultCode": "00",
+      "resultMsg": "NORMAL SERVICE."
+    },
+    "body": {
+      "items": {
+        "item": [
+          {
+            "dateKind": "01",
+            "dateName": "어린이날",
+            "isHoliday": "Y",
+            "locdate": 20230505,
+            "seq": 1
+          },
+          {
+            "dateKind": "01",
+            "dateName": "부처님오신날",
+            "isHoliday": "Y",
+            "locdate": 20230527,
+            "seq": 1
+          },
+          {
+            "dateKind": "01",
+            "dateName": "대체공휴일",
+            "isHoliday": "Y",
+            "locdate": 20230529,
+            "seq": 1
+          }
+        ]
+      },
+      "numOfRows": 10,
+      "pageNo": 1,
+      "totalCount": 3
+    }
+  }
+}
+```
+
+* ✅ **[23/12/25]** `UriComponentsBuilder` 싱글톤 사용시 중첩되면서 URL이 저장되는 현상
+  * 스프링 빈으로 등록하지 않고, 직접 생성하도록 변경
+```
+1. 첫 번째 호출시 /api/v1?year=2023&month=01
+2. 두 번째 호출시 /api/v1?year=2023&month=01&year=2023&month=01
+3. 세 번째 호출시 /api/v1?year=2023&month=01&year=2023&month=01&year=2023&month=01
+```
+
 ## 시스템 개선(v1.0.73)
 ### 이력
-* ✅ 특일 정보 API를 활용하여 예외처리 추가
+* ✅ **[23/11/09]** 특일 정보 API를 활용하여 예외처리 추가
   * 주말뿐 아니라, 공휴일에도 학식을 제공하지 않음.
   * 임시공휴일을 고려하여 매일 API 호출하여 해당 정보를 캐시에 저장한다.
   * 모든 요청마다 공휴일인지 확인한다.
 
 ## 시스템 개선(v1.0.72)
-* ✅ 메뉴 추천시 학식 메뉴 데이터 정합성 이슈
+* ✅ **[23/11/06]** 메뉴 추천시 학식 메뉴 데이터 정합성 이슈
   *  메뉴 추천시에 캐시에서 메뉴를 조회하고 변경 내역을 데이터베이스에 반영한다.
 
 문제 발생 시나리오

--- a/src/main/java/seaung/uoscafeteriamenu/api/korea/holiday/handler/HolidayApiHandler.java
+++ b/src/main/java/seaung/uoscafeteriamenu/api/korea/holiday/handler/HolidayApiHandler.java
@@ -26,10 +26,10 @@ public class HolidayApiHandler {
     private static final String MONTH_FORMAT = "%02d";
 
     private final RestTemplate restTemplate;
-    private final UriComponentsBuilder uriComponentsBuilder;
 
     public ApiResponse<HolidayResponse> callHolidaysApi(LocalDateTime now) {
-        System.out.println(getHolidaysUri(now));
+        URI holidaysUri = getHolidaysUri(now);
+        log.info("url = {}", holidaysUri);
         return restTemplate.exchange(
                 getHolidaysUri(now),
                 HttpMethod.GET,
@@ -40,7 +40,7 @@ public class HolidayApiHandler {
     }
 
     private URI getHolidaysUri(LocalDateTime now) {
-        return uriComponentsBuilder
+        return UriComponentsBuilder.newInstance()
                 .uri(URI.create(API_BASIC_URL))
                 .pathSegment(HOLIDAY_URL_PATH)
                 .queryParam(YEAR_KEY, now.getYear())

--- a/src/main/java/seaung/uoscafeteriamenu/api/korea/holiday/response/HolidayHeader.java
+++ b/src/main/java/seaung/uoscafeteriamenu/api/korea/holiday/response/HolidayHeader.java
@@ -4,7 +4,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@NoArgsConstructor
 public class HolidayHeader {
     private String resultCode;
     private String resultMsg;

--- a/src/main/java/seaung/uoscafeteriamenu/api/korea/holiday/response/HolidayItem.java
+++ b/src/main/java/seaung/uoscafeteriamenu/api/korea/holiday/response/HolidayItem.java
@@ -1,5 +1,7 @@
 package seaung.uoscafeteriamenu.api.korea.holiday.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/seaung/uoscafeteriamenu/api/korea/holiday/response/HolidayItemDeserializer.java
+++ b/src/main/java/seaung/uoscafeteriamenu/api/korea/holiday/response/HolidayItemDeserializer.java
@@ -1,0 +1,44 @@
+package seaung.uoscafeteriamenu.api.korea.holiday.response;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HolidayItemDeserializer extends JsonDeserializer<List<HolidayItem>> {
+    @Override
+    public List<HolidayItem> deserialize(JsonParser jsonParser, DeserializationContext ctxt) throws IOException {
+        JsonNode jsonNode = jsonParser.readValueAsTree();
+
+        if(jsonNode.isArray()) {
+            return getHolidayItemsToArray(jsonNode);
+        }
+
+        return getHolidayItemsToObject(jsonNode);
+    }
+
+    private List<HolidayItem> getHolidayItemsToObject(JsonNode jsonNode) throws JsonProcessingException {
+        ObjectMapper om = new ObjectMapper();
+        List<HolidayItem> holidayItems = new ArrayList<>();
+        HolidayItem holidayItem = om.treeToValue(jsonNode, HolidayItem.class);
+        holidayItems.add(holidayItem);
+
+        return holidayItems;
+    }
+
+    private List<HolidayItem> getHolidayItemsToArray(JsonNode jsonNode) throws JsonProcessingException {
+        ObjectMapper om = new ObjectMapper();
+        List<HolidayItem> holidayItems = new ArrayList<>();
+        for(JsonNode item : jsonNode) {
+            HolidayItem holidayItem = om.treeToValue(item, HolidayItem.class);
+            holidayItems.add(holidayItem);
+        }
+
+        return holidayItems;
+    }
+}

--- a/src/main/java/seaung/uoscafeteriamenu/api/korea/holiday/response/HolidayItems.java
+++ b/src/main/java/seaung/uoscafeteriamenu/api/korea/holiday/response/HolidayItems.java
@@ -1,9 +1,12 @@
 package seaung.uoscafeteriamenu.api.korea.holiday.response;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.List;
 import lombok.Data;
 
 @Data
 public class HolidayItems {
+    @JsonDeserialize(using = HolidayItemDeserializer.class)
     private List<HolidayItem> item;
 }

--- a/src/main/java/seaung/uoscafeteriamenu/api/korea/holiday/response/HolidayResponse.java
+++ b/src/main/java/seaung/uoscafeteriamenu/api/korea/holiday/response/HolidayResponse.java
@@ -4,7 +4,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
-@NoArgsConstructor
 public class HolidayResponse {
     private HolidayHeader header;
     private HolidayBody body;

--- a/src/main/java/seaung/uoscafeteriamenu/global/config/AppConfig.java
+++ b/src/main/java/seaung/uoscafeteriamenu/global/config/AppConfig.java
@@ -41,11 +41,6 @@ public class AppConfig {
     }
 
     @Bean
-    public UriComponentsBuilder UriComponentsBuilder() {
-        return UriComponentsBuilder.newInstance();
-    }
-
-    @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper om = new ObjectMapper();
 

--- a/src/main/java/seaung/uoscafeteriamenu/global/schedule/HolidaySchedule.java
+++ b/src/main/java/seaung/uoscafeteriamenu/global/schedule/HolidaySchedule.java
@@ -20,7 +20,8 @@ public class HolidaySchedule {
     private final HolidayApiService holidayApiService;
     private final TimeProvider timeProvider;
 
-    @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
+    //@Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
+    @Scheduled(cron = "0/10 * * * * ?")
     @Async("uosRestaurantAsyncExecutor")
     public void refreshHolidayInCache() {
         log.info("공휴일 정보 캐시 저장 스케줄링 시작");

--- a/src/test/java/seaung/uoscafeteriamenu/api/korea/holiday/handler/HolidayApiHandlerTest.java
+++ b/src/test/java/seaung/uoscafeteriamenu/api/korea/holiday/handler/HolidayApiHandlerTest.java
@@ -16,6 +16,75 @@ import seaung.uoscafeteriamenu.global.provider.TimeProvider;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+/**
+ * 응답 결과가 item의 value가 Object인 경우
+ * <pre>
+ * {
+ *   "response": {
+ *     "header": {
+ *       "resultCode": "00",
+ *       "resultMsg": "NORMAL SERVICE."
+ *     },
+ *     "body": {
+ *       "items": {
+ *         "item": {
+ *           "dateKind": "01",
+ *           "dateName": "기독탄신일",
+ *           "isHoliday": "Y",
+ *           "locdate": 20231225,
+ *           "seq": 1
+ *         }
+ *       },
+ *       "numOfRows": 10,
+ *       "pageNo": 1,
+ *       "totalCount": 1
+ *     }
+ *   }
+ * }
+ * </pre>
+ *
+ * 응답 결과가 item의 value가 Array인 경우
+ * <pre>
+ *     {
+ *   "response": {
+ *     "header": {
+ *       "resultCode": "00",
+ *       "resultMsg": "NORMAL SERVICE."
+ *     },
+ *     "body": {
+ *       "items": {
+ *         "item": [
+ *           {
+ *             "dateKind": "01",
+ *             "dateName": "어린이날",
+ *             "isHoliday": "Y",
+ *             "locdate": 20230505,
+ *             "seq": 1
+ *           },
+ *           {
+ *             "dateKind": "01",
+ *             "dateName": "부처님오신날",
+ *             "isHoliday": "Y",
+ *             "locdate": 20230527,
+ *             "seq": 1
+ *           },
+ *           {
+ *             "dateKind": "01",
+ *             "dateName": "대체공휴일",
+ *             "isHoliday": "Y",
+ *             "locdate": 20230529,
+ *             "seq": 1
+ *           }
+ *         ]
+ *       },
+ *       "numOfRows": 10,
+ *       "pageNo": 1,
+ *       "totalCount": 3
+ *     }
+ *   }
+ * }
+ * </pre>
+ */
 @SpringBootTest
 class HolidayApiHandlerTest {
 
@@ -26,8 +95,8 @@ class HolidayApiHandlerTest {
     TimeProvider timeProvider;
 
     @Test
-    @DisplayName("시간을 이용하여 공휴일 API를 호출한다.")
-    void callHolidaysApi() {
+    @DisplayName("시간을 이용하여 공휴일 API를 호출하고 응답 결과가 Array 형태 이다.")
+    void callHolidaysApiItemIsObject() {
         // given
         LocalDateTime fixedDateTime = LocalDateTime.of(2023, 1, 1, 0, 0, 0);
         Mockito.when(timeProvider.getCurrentLocalDateTime()).thenReturn(fixedDateTime);
@@ -45,6 +114,25 @@ class HolidayApiHandlerTest {
                         tuple("01", "설날", "Y", "20230122", 1),
                         tuple("01", "설날", "Y", "20230123", 1),
                         tuple("01", "대체공휴일", "Y", "20230124", 1)
+                );
+    }
+
+    @Test
+    @DisplayName("시간을 이용하여 공휴일 API를 호출하고 응답 결과가 Object 형태 이다.")
+    void callHolidaysApi() {
+        // given
+        LocalDateTime fixedDateTime = LocalDateTime.of(2023, 12, 1, 0, 0, 0);
+        Mockito.when(timeProvider.getCurrentLocalDateTime()).thenReturn(fixedDateTime);
+
+        // when
+        ApiResponse<HolidayResponse> response = holidayApiHandler.callHolidaysApi(timeProvider.getCurrentLocalDateTime());
+
+        // then
+        List<HolidayItem> holidays = response.getResponse().getBody().getItems().getItem();
+        assertThat(holidays).hasSize(1)
+                .extracting("dateKind", "dateName", "isHoliday", "locdate", "seq")
+                .contains(
+                        tuple("01", "기독탄신일", "Y", "20231225", 1)
                 );
     }
 }


### PR DESCRIPTION
## 시스템 개선(v1.0.8)
### 이력
* ✅ **[23/12/25]** 공휴일 API 호출 시 필드 타입 문제
  * 같은 item 필드에서 데이터에 따라 Object 또는 Array를 내려줌
  * `JsonDeserializer`를 상속받은 `HolidayItemDeserializer`를 구현하여 해결
```
## 응답 결과가 item의 value가 Object인 경우
{
  "response": {
    "header": {
      "resultCode": "00",
      "resultMsg": "NORMAL SERVICE."
    },
    "body": {
      "items": {
        "item": {
          "dateKind": "01",
          "dateName": "기독탄신일",
          "isHoliday": "Y",
          "locdate": 20231225,
          "seq": 1
        }
      },
      "numOfRows": 10,
      "pageNo": 1,
      "totalCount": 1
    }
  }
}
  
## 응답 결과가 item의 value가 Array인 경우
{
  "response": {
    "header": {
      "resultCode": "00",
      "resultMsg": "NORMAL SERVICE."
    },
    "body": {
      "items": {
        "item": [
          {
            "dateKind": "01",
            "dateName": "어린이날",
            "isHoliday": "Y",
            "locdate": 20230505,
            "seq": 1
          },
          {
            "dateKind": "01",
            "dateName": "부처님오신날",
            "isHoliday": "Y",
            "locdate": 20230527,
            "seq": 1
          },
          {
            "dateKind": "01",
            "dateName": "대체공휴일",
            "isHoliday": "Y",
            "locdate": 20230529,
            "seq": 1
          }
        ]
      },
      "numOfRows": 10,
      "pageNo": 1,
      "totalCount": 3
    }
  }
}
```

* ✅ **[23/12/25]** `UriComponentsBuilder` 싱글톤 사용시 중첩되면서 URL이 저장되는 현상
  * 스프링 빈으로 등록하지 않고, 직접 생성하도록 변경
```
1. 첫 번째 호출시 /api/v1?year=2023&month=01
2. 두 번째 호출시 /api/v1?year=2023&month=01&year=2023&month=01
3. 세 번째 호출시 /api/v1?year=2023&month=01&year=2023&month=01&year=2023&month=01
```